### PR TITLE
Release 0.1.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 ====
+## 0.1.1-dev
+### New features
+* Custom color for active arrows. New card parameter `active_arrow_color`.
+
 ## 0.1.0
 ### New features
 * **BETA.** Basic support for a battery in the *power view*.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 Changelog
 ====
-## 0.1.1-dev
+## 0.1.1b-dev
 ### New features
 * Custom color for active arrows. New card parameter `active_arrow_color`.
+### Fixes
+* Provisional fix for icon sizes (as of HA 0.110.0).
 
 ## 0.1.0
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,11 @@
 Changelog
 ====
-## 0.1.1b-dev
+## 0.1.1
 ### New features
 * Custom color for active arrows. New card parameter `active_arrow_color`.
+* Invert grid icon coloring for consuming/producing. New card parameter `invert_grid_colors`. Default `false`.
 ### Fixes
-* Provisional fix for icon sizes (as of HA 0.110.0).
+* Provisional fix for icon sizes (as of HA 0.110.0). Issue #48.
 
 ## 0.1.0
 ### New features

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ There are many more card parameters available, but it's advised to start with th
 |color_icons|boolean|optional|`true`|To color the consuming icons green and the producing icons yellow. Icon values will have an absolute value. This setting only is affecting the three big icons for *solar*, *home* and *grid*. The arrows have colors by default.|
 |consuming_color|string|optional|The yellow color for `--label-badge-yellow` from your theme. If not available, then `"#f4b400"` will be used.|CSS color code for consuming power icons if `color_icons` is set to `true`. Examples: `"orange"`, `"#ffcc66"` or `"rgb(200,100,50)"`. Don't forget the quotation marks when using the `#` color notation.|
 |producing_color|string|optional|The green color for `--label-badge-green` from your theme. If not available, then `"#0da035"` will be used.|CSS color code for producing power icons if `color_icons` is set to `true`.|
+|invert_grid_colors|boolean|optional|`false`|The default color of the grid icon is green when producing to the grid. And the grid icon is red for consuming from the grid. You can invert that.|
 |active_arrow_color|string|optional|The yellow color for `--paper-item-icon-active-color` from your theme. If not available, then `"#fdd835"` will be used.|CSS color code for active arrow icons.|
 |initial_view|string|optional|`"power"`|The initial view that will displayed. Allowed values are `"power"` for *power view*, `"energy"` for *energy view* and `"money"` for *money view*.|
 |initial_auto_toggle_view|boolean|optional|`false`|The initial state of the auto-toggle for views.|
@@ -346,6 +347,7 @@ A more advanced example for in the `ui-lovelace.yaml` file:
   color_icons: true
   consuming_color: "#33ff33"
   producing_color: "#dd5500"
+  invert_grid_colors: false
   active_arrow_color: "#ffff00"
   initial_view: "energy"
   initial_auto_toggle_view: true

--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ There are many more card parameters available, but it's advised to start with th
 |color_icons|boolean|optional|`true`|To color the consuming icons green and the producing icons yellow. Icon values will have an absolute value. This setting only is affecting the three big icons for *solar*, *home* and *grid*. The arrows have colors by default.|
 |consuming_color|string|optional|The yellow color for `--label-badge-yellow` from your theme. If not available, then `"#f4b400"` will be used.|CSS color code for consuming power icons if `color_icons` is set to `true`. Examples: `"orange"`, `"#ffcc66"` or `"rgb(200,100,50)"`. Don't forget the quotation marks when using the `#` color notation.|
 |producing_color|string|optional|The green color for `--label-badge-green` from your theme. If not available, then `"#0da035"` will be used.|CSS color code for producing power icons if `color_icons` is set to `true`.|
+|active_arrow_color|string|optional|The yellow color for `--paper-item-icon-active-color` from your theme. If not available, then `"#fdd835"` will be used.|CSS color code for active arrow icons.|
 |initial_view|string|optional|`"power"`|The initial view that will displayed. Allowed values are `"power"` for *power view*, `"energy"` for *energy view* and `"money"` for *money view*.|
 |initial_auto_toggle_view|boolean|optional|`false`|The initial state of the auto-toggle for views.|
 |auto_toggle_view_period|integer|optional|`10`|Period in seconds between views when auto-toggle for views is turned on.|
@@ -345,6 +346,7 @@ A more advanced example for in the `ui-lovelace.yaml` file:
   color_icons: true
   consuming_color: "#33ff33"
   producing_color: "#dd5500"
+  active_arrow_color: "#ffff00"
   initial_view: "energy"
   initial_auto_toggle_view: true
   auto_toggle_view_period: 5

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "power-wheel-card",
-  "version": "0.1.1b-dev",
+  "version": "0.1.1",
   "description": "An intuitive way to represent the power and energy that your home is consuming or producing.",
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "power-wheel-card",
-  "version": "0.1.1-dev",
+  "version": "0.1.1b-dev",
   "description": "An intuitive way to represent the power and energy that your home is consuming or producing.",
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "power-wheel-card",
-  "version": "0.1.0",
+  "version": "0.1.1-dev",
   "description": "An intuitive way to represent the power and energy that your home is consuming or producing.",
   "directories": {
     "test": "test"

--- a/power-wheel-card.js
+++ b/power-wheel-card.js
@@ -5,7 +5,7 @@
  *
  */
 
-const __VERSION = "0.1.1b-dev";
+const __VERSION = "0.1.1";
 
 const LitElement = Object.getPrototypeOf(customElements.get("hui-view"));
 const html = LitElement.prototype.html;
@@ -137,7 +137,9 @@ class PowerWheelCard extends LitElement {
     const valueStrSoC = typeof valSoC === 'undefined' ? 'unavailable' : `(${valSoC}%)`;
     const stateObj = this.hass.states[entity];
     const icon = configIcon ? configIcon : (stateObj && stateObj.attributes.icon ? stateObj.attributes.icon : defaultIcon);
-    const classValue = PowerWheelCard._generateClass(val);
+    // Invert producing/consuming for grid icon when user wants to invert_grid_colors
+    const classValue = PowerWheelCard._generateClass(val *
+      (defaultIcon === 'mdi:transmission-tower' && this.config.invert_grid_colors ? -1 : 1));
 
     return {
       stateObj,
@@ -663,6 +665,7 @@ class PowerWheelCard extends LitElement {
     config.producing_color = config.color_icons
       ? (config.producing_color ? config.producing_color : 'var(--label-badge-green, #0da035)')
       : 'var(--state-icon-unavailable-color, #bdbdbd)';
+    config.invert_grid_colors = config.invert_grid_colors ? (config.invert_grid_colors == true) : false;
     config.active_arrow_color = config.active_arrow_color
       ? config.active_arrow_color
       : 'var(--paper-item-icon-active-color, #fdd835)';

--- a/power-wheel-card.js
+++ b/power-wheel-card.js
@@ -5,7 +5,7 @@
  *
  */
 
-const __VERSION = "0.1.0";
+const __VERSION = "0.1.1-dev";
 
 const LitElement = Object.getPrototypeOf(customElements.get("hui-view"));
 const html = LitElement.prototype.html;
@@ -93,9 +93,6 @@ class PowerWheelCard extends LitElement {
         color: var(--paper-item-icon-color, #44739e);
         width: 48px;
         height: 48px;
-      }
-      ha-icon.active {
-        color: var(--paper-item-icon-active-color, #fdd835);
       }
       ha-icon.inactive {
         color: var(--state-icon-unavailable-color, #bdbdbd);
@@ -489,6 +486,9 @@ class PowerWheelCard extends LitElement {
         ha-icon.producing {
           color: ${this.config.producing_color};
         }
+        ha-icon.active {
+          color: ${this.config.active_arrow_color};
+        }
       </style>
       <ha-card>
         ${this.messages.length ? this.messages.map((message) => { return html`<div class="message ${message.type}">${message.text}</div>`}) : ''}
@@ -661,6 +661,9 @@ class PowerWheelCard extends LitElement {
     config.producing_color = config.color_icons
       ? (config.producing_color ? config.producing_color : 'var(--label-badge-green, #0da035)')
       : 'var(--state-icon-unavailable-color, #bdbdbd)';
+    config.active_arrow_color = config.active_arrow_color
+      ? config.active_arrow_color
+      : 'var(--paper-item-icon-active-color, #fdd835)';
     if (config.initial_view && !['power', 'energy', 'money'].includes(config.initial_view)) {
       throw new Error("Initial_view should 'power', 'energy' or 'money'");
     }

--- a/power-wheel-card.js
+++ b/power-wheel-card.js
@@ -5,7 +5,7 @@
  *
  */
 
-const __VERSION = "0.1.1-dev";
+const __VERSION = "0.1.1b-dev";
 
 const LitElement = Object.getPrototypeOf(customElements.get("hui-view"));
 const html = LitElement.prototype.html;
@@ -89,6 +89,7 @@ class PowerWheelCard extends LitElement {
         cursor: pointer;
       }
       ha-icon {
+        --mdc-icon-size: 48px;
         transition: all 0.4s ease-in-out;
         color: var(--paper-item-icon-color, #44739e);
         width: 48px;
@@ -98,6 +99,7 @@ class PowerWheelCard extends LitElement {
         color: var(--state-icon-unavailable-color, #bdbdbd);
       }
       ha-icon#toggle-button {
+        --mdc-icon-size: 24px;
         padding-top: 4px;
         width: 24px;
         height: 24px;

--- a/test/basic_config.test.js
+++ b/test/basic_config.test.js
@@ -78,6 +78,7 @@ describe('<power-wheel-card> with most basic config', () => {
     assert.equal(card.config.money_unit, '€', 'Card parameter money_unit should have default value');
     assert.equal(card.config.consuming_color, 'var(--state-icon-unavailable-color, #bdbdbd)', 'Card parameter consuming_color should have default value');
     assert.equal(card.config.producing_color, 'var(--state-icon-unavailable-color, #bdbdbd)', 'Card parameter producing_color should have default value');
+    assert.equal(card.config.active_arrow_color, 'var(--paper-item-icon-active-color, #fdd835)', 'Card parameter active_arrow_color should have default value');
     assert.equal(card.config.initial_view, 'power', 'Card parameter initial_view should have default value');
     assert.isFalse(card.config.initial_auto_toggle_view, 'Card parameter initial_auto_toggle_view should be default false');
     assert.equal(card.config.auto_toggle_view_period, 10, 'Card parameter auto_toggle_view_period should have default value');

--- a/test/color_icons.test.js
+++ b/test/color_icons.test.js
@@ -20,6 +20,9 @@ describe('<power-wheel-card> with icon coloring', () => {
       grid_energy_production_entity: "sensor.grid_energy_production",
       energy_consumption_rate: 0.20,
       money_unit: '$',
+      consuming_color: "#550000",
+      producing_color: "#005500",
+      active_arrow_color: "#000055",
     };
     hass = {
       states: {
@@ -104,15 +107,18 @@ describe('<power-wheel-card> with icon coloring', () => {
     await card.setConfig(config);
   };
 
-it('has config values', () => {
+  it('has config values', () => {
     assert.isTrue(card.config.color_icons, 'Card parameter color_icons should be set');
-    assert.equal(card.config.consuming_color, 'var(--label-badge-yellow, #f4b400)', 'Card parameter consuming_color should be yellow');
-    assert.equal(card.config.producing_color, 'var(--label-badge-green, #0da035)', 'Card parameter producing_color should be green');
+    assert.equal(card.config.consuming_color, '#550000', 'Card parameter consuming_color should be set');
+    assert.equal(card.config.producing_color, '#005500', 'Card parameter producing_color should be set');
+    assert.equal(card.config.active_arrow_color, '#000055', 'Card parameter active_arrow_color should be set');
   });
 
   it('uses color values', () => {
-    assert.equal(window.getComputedStyle(card.shadowRoot.querySelector('ha-icon.consuming'), null).getPropertyValue('color'), 'rgb(244, 180, 0)', 'Consuming icon color should be #f4b400');
-    assert.equal(window.getComputedStyle(card.shadowRoot.querySelector('ha-icon.producing'), null).getPropertyValue('color'), 'rgb(13, 160, 53)', 'Producing icon color should be #0da035');
+    assert.equal(window.getComputedStyle(card.shadowRoot.querySelector('ha-icon.consuming'), null).getPropertyValue('color'), 'rgb(85, 0, 0)', 'Consuming icon color should be #550000');
+    assert.equal(window.getComputedStyle(card.shadowRoot.querySelector('ha-icon.producing'), null).getPropertyValue('color'), 'rgb(0, 85, 0)', 'Producing icon color should be #005500');
+    assert.equal(window.getComputedStyle(card.shadowRoot.querySelector('ha-icon.active'), null).getPropertyValue('color'), 'rgb(0, 0, 85)', 'Active arrow icon color should be #000055');
+    assert.equal(window.getComputedStyle(card.shadowRoot.querySelector('ha-icon.inactive'), null).getPropertyValue('color'), 'rgb(189, 189, 189)', 'Inactive arrow icon color should be #bdbdbd');
   });
 
   it('displays values in power view when consuming from the grid', () => {

--- a/test/invert_grid_colors.test.js
+++ b/test/invert_grid_colors.test.js
@@ -4,10 +4,8 @@ import './hui-view-mock.js';
 import '../power-wheel-card.js';
 import {setCard, setCardAllInactive} from './test_main.js';
 
-describe('<power-wheel-card> with most basic config', () => {
+describe('<power-wheel-card> with inverted grid colors', () => {
   let card, hass, config;
-
-  /** Tests are extended in energy_capable. **/
 
   beforeEach(async () => {
     config = {
@@ -15,7 +13,8 @@ describe('<power-wheel-card> with most basic config', () => {
       solar_power_entity: "sensor.solar_power",
       grid_power_consumption_entity: "sensor.grid_power_consumption",
       grid_power_production_entity: "sensor.grid_power_production",
-      color_icons: false,
+      color_icons: true,
+      invert_grid_colors: true,
     };
     hass = {
       states: {
@@ -64,56 +63,8 @@ describe('<power-wheel-card> with most basic config', () => {
     await card.setConfig(config);
   };
 
-  it('has set default config values', () => {
-    assert.isFalse(card.config.color_icons, 'Card parameter color_icons should be set');
-    assert.equal(card.config.production_is_positive, 1, 'Card parameter production_is_positive should be default 1');
-    assert.isFalse(card.config.debug, 'Card parameter debug should be default false');
-    assert.equal(card.config.title, 'Power wheel', 'Card parameter title should have default value');
-    assert.equal(card.config.title_power, 'Power wheel', 'Card parameter title_power should have default value');
-    assert.equal(card.config.title_energy, 'Power wheel', 'Card parameter title_energy should have default value');
-    assert.equal(card.config.title_money, 'Power wheel', 'Card parameter title_money should have default value');
-    assert.equal(card.config.power_decimals, 0, 'Card parameter power_decimals should have default value');
-    assert.equal(card.config.energy_decimals, 3, 'Card parameter energy_decimals should have default value');
-    assert.equal(card.config.money_decimals, 2, 'Card parameter money_decimals should have default value');
-    assert.equal(card.config.money_unit, '€', 'Card parameter money_unit should have default value');
-    assert.equal(card.config.consuming_color, 'var(--state-icon-unavailable-color, #bdbdbd)', 'Card parameter consuming_color should have default value');
-    assert.equal(card.config.producing_color, 'var(--state-icon-unavailable-color, #bdbdbd)', 'Card parameter producing_color should have default value');
-    assert.equal(card.config.active_arrow_color, 'var(--paper-item-icon-active-color, #fdd835)', 'Card parameter active_arrow_color should have default value');
-    assert.equal(card.config.initial_view, 'power', 'Card parameter initial_view should have default value');
-    assert.isFalse(card.config.invert_grid_colors, 'Card parameter invert_grid_colors should be default false');
-    assert.isFalse(card.config.initial_auto_toggle_view, 'Card parameter initial_auto_toggle_view should be default false');
-    assert.equal(card.config.auto_toggle_view_period, 10, 'Card parameter auto_toggle_view_period should have default value');
-  });
-
-  it('has set card property values after setConfig', () => {
-    assert.isFalse(card.autoToggleView, 'Card property autoToggleView should be default false');
-    assert.deepEqual(card.sensors, ["sensor.solar_power", "sensor.grid_power_consumption", "sensor.grid_power_production"], 'Card property sensors should have default value');
-    assert.equal(card.view, 'power', 'Card property view should have default value');
-    assert.equal(card.views.power.title, 'Power wheel', 'Card property views should have default value for power view title');
-    assert.isFalse(card.views.power.batteryCapable, 'Card property views should have default value for power view battery capability');
-    assert.equal(card.views.energy.title, 'Power wheel', 'Card property views should have default value for energy view title');
-    assert.equal(card.views.money.title, 'Power wheel', 'Card property views should have default value for money view title');
-    assert.isFalse(card.views.energy.capable, 'Card property views should have default value for energy capable');
-    assert.isFalse(card.views.money.capable, 'Card property views should have default value for money capable');
-    assert.isFalse(card.views.power.oneGridSensor, 'Card property views should have value set for power oneGridSensor');
-    assert.isTrue(card.views.power.twoGridSensors, 'Card property views should have value set for power twoGridSensors');
-  });
-
-  it('has no warnings or errors', () => {
-    assert.equal(card.shadowRoot.querySelectorAll('.message').length, 0, 'Number of messages should be zero');
-  });
-
-  it('uses color values', () => {
-    // After testing this, the other tests can just check for class values 'inactive', 'consuming' and 'producing'.
-    assert.equal(window.getComputedStyle(card.shadowRoot.querySelector('ha-icon.consuming'), null).getPropertyValue('color'), 'rgb(189, 189, 189)', 'Consuming icon color should be #bdbdbd');
-    assert.equal(window.getComputedStyle(card.shadowRoot.querySelector('ha-icon.producing'), null).getPropertyValue('color'), 'rgb(189, 189, 189)', 'Producing icon color should be #bdbdbd');
-    assert.equal(window.getComputedStyle(card.shadowRoot.querySelector('ha-icon.active'), null).getPropertyValue('color'), 'rgb(253, 216, 53)', 'Active arrow icon color should be #fdd835');
-    assert.equal(window.getComputedStyle(card.shadowRoot.querySelector('ha-icon.inactive'), null).getPropertyValue('color'), 'rgb(189, 189, 189)', 'Inactive arrow icon color should be #bdbdbd');
-  });
-
-  it('displays values', () => {
-    assert.equal(card.shadowRoot.querySelector('#title').innerText, 'Power wheel', 'Should have title');
-    assert.equal(card.shadowRoot.querySelector('#unit').innerText, 'W', 'Should have unit');
+  it('has config values', () => {
+    assert.isTrue(card.config.invert_grid_colors, 'Card parameter invert_grid_colors should be set');
   });
 
   it('has ui elements', () => {
@@ -139,8 +90,8 @@ describe('<power-wheel-card> with most basic config', () => {
 
   it('displays values when consuming from the grid', () => {
     assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '500', 'Solar should have correct value');
-    assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-1800', 'Grid should have correct value');
-    assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-2300', 'Home should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '1800', 'Grid should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '2300', 'Home should have correct value');
     assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
     assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
     assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
@@ -148,7 +99,7 @@ describe('<power-wheel-card> with most basic config', () => {
 
   it('has ui elements when consuming from the grid', () => {
     assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('producing'), 'Solar icon should be producing');
-    assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('consuming'), 'Grid icon should be consuming');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('producing'), 'Grid icon should be producing'); // !
     assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('consuming'), 'Home icon should be consuming');
     assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
     assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
@@ -163,7 +114,7 @@ describe('<power-wheel-card> with most basic config', () => {
 
     assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '500', 'Solar should have correct value');
     assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '50', 'Grid should have correct value');
-    assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-450', 'Home should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '450', 'Home should have correct value');
     assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow should have correct value');
     assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow should have correct value');
     assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
@@ -173,7 +124,7 @@ describe('<power-wheel-card> with most basic config', () => {
     await setCardProducingToGrid();
 
     assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('producing'), 'Solar icon should be producing');
-    assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('producing'), 'Grid icon should be producing');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('consuming'), 'Grid icon should be consuming'); // !
     assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('consuming'), 'Home icon should be consuming');
     assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
     assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
@@ -211,8 +162,8 @@ describe('<power-wheel-card> with most basic config', () => {
   it('displays values when solar inverter consumes power', async () => {
     await setCardSolarConsuming();
 
-    assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '-5', 'Solar should have correct value');
-    assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-5', 'Grid should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '5', 'Solar should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '5', 'Grid should have correct value');
     assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '0', 'Home should have correct value');
     assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
     assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow should have a value');
@@ -222,8 +173,8 @@ describe('<power-wheel-card> with most basic config', () => {
   it('has ui elements when solar inverter consumes power', async () => {
     await setCardSolarConsuming();
 
-    assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('consuming'), 'Solar icon should be inactive');
-    assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('consuming'), 'Grid icon should be inactive');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('consuming'), 'Solar icon should be consuming');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('producing'), 'Grid icon should be producing'); // !
     assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('inactive'), 'Home icon should be inactive');
     assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
     assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-top-left', 'Solar2Home icon should be reversed icon');
@@ -231,20 +182,6 @@ describe('<power-wheel-card> with most basic config', () => {
     assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('inactive'), 'Solar2Grid arrow icon should be inactive');
     assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('active'), 'Solar2Home arrow icon should be inactive');
     assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('active'), 'Grid2Home arrow icon should be active');
-  });
-
-  it('updates when sensor value changes', async () => {
-    assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '500', 'Solar should have value set');
-    hass.states['sensor.solar_power'].state = "501";
-    card.setAttribute('hass', JSON.stringify(hass));
-    await elementUpdated(card);
-    await card.setConfig(config);
-
-    assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '501', 'Solar should have changed value');
-  });
-
-  it('has card size', () => {
-    assert.equal(card.getCardSize(), 5, 'getCardSize should respond');
   });
 
 });


### PR DESCRIPTION
## 0.1.1
### New features
* Custom color for active arrows. New card parameter `active_arrow_color`.
* Invert grid icon coloring for consuming/producing. New card parameter `invert_grid_colors`. Default `false`.
### Fixes
* Provisional fix for icon sizes (as of HA 0.110.0). Issue #48.
