### PR TITLE
Release 0.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ Changelog
 ### New features
 * Allowing to hide the title. Default value for `title` is empty now. If you want the previous behavior you could add `title: 'Power wheel'` to your config. Issue #51.
 * ** BETA.** You can switch the polarity of `battery_power_entity` with the new card parameter `charging_is_positive`. No need to make an extra template sensor for this anymore. Issue #46.
+### Improvements
+* Removed deprecated input parameter `energy_price`. This parameter was deprecated since version 0.1.0. 
 
 ## 0.1.1
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 Changelog
 ====
+## 0.1.2-dev
+### New features
+* Allowing to hide the title. Default value for `title` is empty now. If you want the previous behavior you could add `title: 'Power wheel'` to your config.
+
 ## 0.1.1
 ### New features
 * Custom color for active arrows. New card parameter `active_arrow_color`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@ Changelog
 ====
 ## 0.1.2-dev
 ### New features
-* Allowing to hide the title. Default value for `title` is empty now. If you want the previous behavior you could add `title: 'Power wheel'` to your config.
+* Allowing to hide the title. Default value for `title` is empty now. If you want the previous behavior you could add `title: 'Power wheel'` to your config. Issue #51.
+* ** BETA.** You can switch the polarity of `battery_power_entity` with the new card parameter `charging_is_positive`. No need to make an extra template sensor for this anymore. Issue #46.
 
 ## 0.1.1
 ### New features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,13 @@
 Changelog
 ====
-## 0.1.2-dev
+## 0.1.2
 ### New features
 * Allowing to hide the title. Default value for `title` is empty now. If you want the previous behavior you could add `title: 'Power wheel'` to your config. Issue #51.
 * ** BETA.** You can switch the polarity of `battery_power_entity` with the new card parameter `charging_is_positive`. No need to make an extra template sensor for this anymore. Issue #46.
 ### Improvements
-* Removed deprecated input parameter `energy_price`. This parameter was deprecated since version 0.1.0. 
+* Removed deprecated input parameter `energy_price`. This parameter was deprecated since version 0.1.0.
+### Fixes 
+* After a startup of HA sensor validation errors stayed visible since the new startup order of HA 0.111.0. Sensor validation is disabled temporarily. 
 
 ## 0.1.1
 ### New features

--- a/README.md
+++ b/README.md
@@ -259,7 +259,8 @@ There are many more card parameters available, but it's advised to start with th
 |grid_power_consumption_entity (A)|string|optional, always together with B| |Entity id of your sensor for power that you are consuming from the grid. E.g. `sensor.YOUR_GRID_POWER_CONSUMPTION_SENSOR`. See requirements above.|
 |grid_power_production_entity (B)|string|optional, always together with A| |Entity id of your sensor for power that you are producing to the grid. E.g. `sensor.YOUR_GRID_POWER_PRODUCTION_SENSOR`. See requirements above.|
 |BETA: battery_power_entity|string|optional| |Entity id of your sensor for power you use to charge the battery. Charging should have positive values. Discharging should have negative values. Battery feature is in BETA, [expect issues](#Known-issues-for-the-battery-feature).|
-|BETA: battery_soc_entity|string|optional| |Entity id of your sensor for *state of charge* of your battery. Unit should be %. Battery feature is in BETA, [expect issues](#Known-issues-for-the-battery-feature).|
+|BETA: charging_is_positive|boolean|optional|`true`|You can specify the polarity of your input sensor `battery_power_entity`. Use `true` for charging the battery has positive values in your input sensor. Use `false` for charging the battery has negative values.|
+|BETA: battery_soc_entity|string|optional| |Entity id of your sensor for *state of charge* of your battery. Unit should be %.|
 |solar_energy_entity|string|optional|Default the *energy view* will not be enabled.|Entity id of your solar energy sensor. E.g. `sensor.YOUR_SOLAR_ENERGY_SENSOR`. See requirements above.|
 |grid_energy_consumption_entity (D)|string|optional, always together with E|Default the *energy view* will not be enabled.|Entity id of your sensor for energy that's consumed from the grid. E.g. `sensor.YOUR_GRID_ENERGY_CONSUMPTION_SENSOR`. See requirements above.|
 |grid_energy_production_entity (E)|string|optional, always together with D|Default the *energy view* will not be enabled.|Entity id of your sensor for energy that's produced to the grid. E.g. `sensor.YOUR_GRID_ENERGY_PRODUCTION_SENSOR`. See requirements above.|
@@ -330,7 +331,9 @@ A more advanced example for in the `ui-lovelace.yaml` file:
   solar_power_entity: sensor.YOUR_SOLAR_POWER_SENSOR
   grid_power_consumption_entity: sensor.YOUR_GRID_POWER_CONSUMPTION_SENSOR
   grid_power_production_entity: sensor.YOUR_GRID_POWER_PRODUCTION_SENSOR
+  production_is_positive: true
   battery_power_entity: sensor.YOUR_BATTERY_POWER_SENSOR  # Battery feature is in BETA, expect issues.
+  charging_is_positive: true  # Battery feature is in BETA, expect issues.
   battery_soc_entity: sensor.YOUR_BATTERY_SOC_SENSOR  # Battery feature is in BETA, expect issues.
   solar_energy_entity: sensor.YOUR_SOLAR_ENERGY_SENSOR
   grid_energy_consumption_entity: sensor.YOUR_GRID_ENERGY_CONSUMPTION_SENSOR

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ views:
   - id: example_view
     cards:
       - type: custom:power-wheel-card
+        title: "Power wheel"
         solar_power_entity: sensor.YOUR_SOLAR_POWER_SENSOR
         grid_power_consumption_entity: sensor.YOUR_GRID_POWER_CONSUMPTION_SENSOR
         grid_power_production_entity: sensor.YOUR_GRID_POWER_PRODUCTION_SENSOR
@@ -250,7 +251,7 @@ There are many more card parameters available, but it's advised to start with th
 | Parameter | Type | Mandatory? | Default | Description |
 |-----------|------|------------|---------|-------------|
 |type|string|**required**| |Type of the card. Use `"custom:power-wheel-card"`.|
-|title|string|optional|`"Power wheel"`|Title of the card in all views, if not overridden with a title per view.|
+|title|string|optional|No title|Title of the card in all views, if not overridden with a title per view.|
 |title_power|string|optional|Value of `title`.|Title of the card in *power view*.|
 |title_energy|string|optional|Value of `title`.|Title of the card in *energy view*.|
 |title_money|string|optional|Value of `title`.|Title of the card in *money view*.|

--- a/README.md
+++ b/README.md
@@ -266,7 +266,6 @@ There are many more card parameters available, but it's advised to start with th
 |grid_energy_production_entity (E)|string|optional, always together with D|Default the *energy view* will not be enabled.|Entity id of your sensor for energy that's produced to the grid. E.g. `sensor.YOUR_GRID_ENERGY_PRODUCTION_SENSOR`. See requirements above.|
 |energy_consumption_rate|float|optional|Default the *money view* will not be enabled.|The rate of your energy consumed from the grid per unit of energy. E.g. `0.20`.|
 |energy_production_rate|float|optional|The value of `energy_consumption_rate`.|The rate of your energy produced to the grid per unit of energy. E.g. `0.15`.|
-|energy_price *(deprecated)*|float|optional| |Deprecated. Please use `energy_consumption_rate` and evt. the optional `energy_production_rate` as of version 0.0.13.|
 |money_unit|string|optional|`"€"`|The unit of `energy_consumption_rate` and `energy_production_rate`. This unit will be used for displaying all money values.|
 |solar_icon|string|optional|The icon of your own customized solar sensor(s). If not available, then `"mdi:weather-sunny"` will be used.|Icon for solar power and energy.|
 |grid_icon|string|optional|The icon of your own customized grid sensor(s) if its entity parameter is set. If not available, then `"mdi:transmission-tower"` will be used.|Icon for grid power and energy.|

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "power-wheel-card",
-  "version": "0.1.1",
+  "version": "0.1.2-dev",
   "description": "An intuitive way to represent the power and energy that your home is consuming or producing.",
   "directories": {
     "test": "test"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "power-wheel-card",
-  "version": "0.1.2-dev",
+  "version": "0.1.2",
   "description": "An intuitive way to represent the power and energy that your home is consuming or producing.",
   "directories": {
     "test": "test"

--- a/power-wheel-card.js
+++ b/power-wheel-card.js
@@ -5,7 +5,7 @@
  *
  */
 
-const __VERSION = "0.1.2-dev";
+const __VERSION = "0.1.2";
 
 const LitElement = Object.getPrototypeOf(customElements.get("hui-view"));
 const html = LitElement.prototype.html;
@@ -390,7 +390,7 @@ class PowerWheelCard extends LitElement {
     } else {
       PowerWheelCard._logConsole(`Version: ${__VERSION}`);
     }
-    this._validateSensors();
+    // this._validateSensors(); // todo: Have to find a better trigger than firstUpdated. Disabled in version 0.1.2 because new startup order in HA 0.111.0.
   }
 
   _sensorChangeDetected(oldValue) {

--- a/power-wheel-card.js
+++ b/power-wheel-card.js
@@ -181,11 +181,16 @@ class PowerWheelCard extends LitElement {
       ? undefined : value * this.config.production_is_positive;
   }
 
+  _setBatteryPolarity(value) {
+    return typeof value === 'undefined'
+      ? undefined : value * this.config.charging_is_positive;
+  }
+
   // Get all entity states (view dependent) and save in this.input
   // Since battery functions this.input.grid_solo_production is not always the same as this.data.solar2grid anymore.
   _saveEntityStates(solar_entity, grid_production_entity, grid_consumption_entity, battery_entity, grid_entity, home_entity) {
     this.input.solar_production = this._getEntityState(solar_entity);
-    this.input.battery_charging = this._getEntityState(battery_entity);
+    this.input.battery_charging = this._setBatteryPolarity(this._getEntityState(battery_entity));
     this.input.home_production = this._setPolarity(this._getEntityState(home_entity));
     if (this.views[this.view].twoGridSensors) {
       this.input.grid_solo_production = this._getEntityState(grid_production_entity);
@@ -639,6 +644,8 @@ class PowerWheelCard extends LitElement {
     if (config.grid_power_consumption_entity && !config.grid_power_production_entity) {
       throw new Error('You need to define a grid_power_production_entity');
     }
+    config.charging_is_positive = config.charging_is_positive !== false;
+    config.charging_is_positive = config.charging_is_positive ? 1 : -1;
     config.production_is_positive = config.production_is_positive !== false;
     config.production_is_positive = config.production_is_positive ? 1 : -1;
     config.title = config.title ? config.title : '';

--- a/power-wheel-card.js
+++ b/power-wheel-card.js
@@ -391,9 +391,6 @@ class PowerWheelCard extends LitElement {
       PowerWheelCard._logConsole(`Version: ${__VERSION}`);
     }
     this._validateSensors();
-    if (this.config.energy_price) {
-      this._addMessage('warn', 'Deprecated card parameter \'energy_price\' is used. Please replace it by \'energy_consumption_rate\' in your setup.');
-    }
   }
 
   _sensorChangeDetected(oldValue) {
@@ -686,9 +683,6 @@ class PowerWheelCard extends LitElement {
     }
     config.auto_toggle_view_period = config.auto_toggle_view_period ? config.auto_toggle_view_period : 10;
     config.debug = config.debug ? config.debug : false;
-    if (config.energy_price && config.energy_consumption_rate === undefined) {
-      config.energy_consumption_rate = config.energy_price;
-    }
     if (config.energy_production_rate === undefined && config.energy_consumption_rate) {
       config.energy_production_rate = config.energy_consumption_rate;
     }

--- a/power-wheel-card.js
+++ b/power-wheel-card.js
@@ -5,7 +5,7 @@
  *
  */
 
-const __VERSION = "0.1.1";
+const __VERSION = "0.1.2-dev";
 
 const LitElement = Object.getPrototypeOf(customElements.get("hui-view"));
 const html = LitElement.prototype.html;
@@ -42,6 +42,7 @@ class PowerWheelCard extends LitElement {
         padding: 4px 0 12px;
         display: flex;
         justify-content: space-between;
+        min-height: 12px;
       }
       ha-card .wheel {
         position: relative;
@@ -416,7 +417,6 @@ class PowerWheelCard extends LitElement {
     this.views.energy.unit = this._defineUnit('energy', this.config.solar_energy_entity, this.config.grid_energy_entity,
       this.config.grid_energy_consumption_entity, this.config.grid_energy_production_entity);
     this.views.money.unit = this.config.money_unit;
-    // this.views = { ...this.views };
 
     if (this.view === 'money' && this.views.money.capable) {
       // Calculate energy values first
@@ -641,7 +641,7 @@ class PowerWheelCard extends LitElement {
     }
     config.production_is_positive = config.production_is_positive !== false;
     config.production_is_positive = config.production_is_positive ? 1 : -1;
-    config.title = config.title ? config.title : 'Power wheel';
+    config.title = config.title ? config.title : '';
     config.title_power = config.title_power ? config.title_power : config.title;
     config.title_energy = config.title_energy ? config.title_energy : config.title;
     config.title_money = config.title_money ? config.title_money : config.title;

--- a/test/basic_config.test.js
+++ b/test/basic_config.test.js
@@ -12,6 +12,7 @@ describe('<power-wheel-card> with most basic config', () => {
   beforeEach(async () => {
     config = {
       type: "custom:power-wheel-card",
+      title: "Power wheel",
       solar_power_entity: "sensor.solar_power",
       grid_power_consumption_entity: "sensor.grid_power_consumption",
       grid_power_production_entity: "sensor.grid_power_production",

--- a/test/basic_config.test.js
+++ b/test/basic_config.test.js
@@ -68,6 +68,7 @@ describe('<power-wheel-card> with most basic config', () => {
   it('has set default config values', () => {
     assert.isFalse(card.config.color_icons, 'Card parameter color_icons should be set');
     assert.equal(card.config.production_is_positive, 1, 'Card parameter production_is_positive should be default 1');
+    assert.equal(card.config.charging_is_positive, 1, 'Card parameter charging_is_positive should be default 1');
     assert.isFalse(card.config.debug, 'Card parameter debug should be default false');
     assert.equal(card.config.title, 'Power wheel', 'Card parameter title should have default value');
     assert.equal(card.config.title_power, 'Power wheel', 'Card parameter title_power should have default value');

--- a/test/basic_one_grid_sensor.test.js
+++ b/test/basic_one_grid_sensor.test.js
@@ -69,7 +69,7 @@ describe('<power-wheel-card> with most basic config for one grid sensor', () => 
   });
 
   it('displays values', () => {
-    assert.equal(card.shadowRoot.querySelector('#title').innerText, "Power wheel");
+    assert.equal(card.shadowRoot.querySelector('#title').innerText, "");
     assert.equal(card.shadowRoot.querySelector('#unit').innerText, "W");
   });
 

--- a/test/basic_one_grid_sensor_switched_polarity.test.js
+++ b/test/basic_one_grid_sensor_switched_polarity.test.js
@@ -12,6 +12,7 @@ describe('<power-wheel-card> with most basic config for one grid sensor with swi
   beforeEach(async () => {
     config = {
       type: "custom:power-wheel-card",
+      title: "Power wheel",
       solar_power_entity: "sensor.solar_power",
       grid_power_entity: "sensor.grid_power",
       production_is_positive: false,

--- a/test/battery_capable_switched_polarity.test.js
+++ b/test/battery_capable_switched_polarity.test.js
@@ -1,0 +1,446 @@
+import '../bower_components/webcomponentsjs/webcomponents-loader';
+import {assert, elementUpdated} from '@open-wc/testing';
+import './hui-view-mock.js';
+import '../power-wheel-card.js';
+import {setCard, setCardAllInactive} from './test_main.js';
+
+describe('<power-wheel-card> with battery power sensor with switched polarity', () => {
+  let card, hass, config;
+
+  /** Tests are based on battery_capable. **/
+
+  beforeEach(async () => {
+    config = {
+      type: "custom:power-wheel-card",
+      solar_power_entity: "sensor.solar_power",
+      grid_power_consumption_entity: "sensor.grid_power_consumption",
+      grid_power_production_entity: "sensor.grid_power_production",
+      battery_power_entity: "sensor.battery_power",
+      charging_is_positive: false,
+      color_icons: false,
+    };
+    hass = {
+      // Battery, Grid and Solar are delivering to Home
+      states: {
+        "sensor.solar_power": {
+          attributes: {
+            unit_of_measurement: "W",
+            friendly_name: "Solar Power",
+          },
+          entity_id: "sensor.solar_power",
+          state: "500",
+        },
+        "sensor.grid_power_consumption": {
+          attributes: {
+            unit_of_measurement: "W",
+          },
+          entity_id: "sensor.grid_power_consumption",
+          state: "1800",
+        },
+        "sensor.grid_power_production": {
+          attributes: {
+            unit_of_measurement: "W",
+          },
+          entity_id: "sensor.grid_power_production",
+          state: "0",
+        },
+        "sensor.battery_power": {
+          attributes: {
+            unit_of_measurement: "W",
+          },
+          entity_id: "sensor.battery_power",
+          state: "300",
+        },
+      },
+    };
+
+    card = await setCard(hass, config);
+});
+
+  const setCardProducingToGrid = async () => {
+    hass.states['sensor.grid_power_consumption'].state = "0";
+    hass.states['sensor.grid_power_production'].state = "50";
+    hass.states['sensor.battery_power'].state = "-100";
+    card.setAttribute('hass', JSON.stringify(hass));
+    await elementUpdated(card);
+    await card.setConfig(config);
+  };
+
+  const setCardBatteryChargedBySolar = async () => {
+    hass.states['sensor.grid_power_consumption'].state = "0";
+    hass.states['sensor.grid_power_production'].state = "0";
+    hass.states['sensor.battery_power'].state = "-280";
+    card.setAttribute('hass', JSON.stringify(hass));
+    await elementUpdated(card);
+    await card.setConfig(config);
+  };
+
+  const setCardBatteryChargedBySolarAndProducingToGrid = async () => {
+    hass.states['sensor.grid_power_consumption'].state = "0";
+    hass.states['sensor.grid_power_production'].state = "100";
+    hass.states['sensor.battery_power'].state = "-280";
+    card.setAttribute('hass', JSON.stringify(hass));
+    await elementUpdated(card);
+    await card.setConfig(config);
+  };
+
+  const setCardBatteryChargedByGrid = async () => {
+    hass.states['sensor.solar_power'].state = "0";
+    hass.states['sensor.grid_power_consumption'].state = "1800";
+    hass.states['sensor.grid_power_production'].state = "0";
+    hass.states['sensor.battery_power'].state = "-280";
+    card.setAttribute('hass', JSON.stringify(hass));
+    await elementUpdated(card);
+    await card.setConfig(config);
+  };
+
+  const setCardBatteryDischargedWhenProducingToGrid = async () => {
+    hass.states['sensor.solar_power'].state = "0";
+    hass.states['sensor.battery_power'].state = "1228";
+    hass.states['sensor.grid_power_consumption'].state = "0";
+    hass.states['sensor.grid_power_production'].state = "171";
+    card.setAttribute('hass', JSON.stringify(hass));
+    await elementUpdated(card);
+    await card.setConfig(config);
+  };
+
+  const setCardBatteryDischargedWhenProducingToGridAndSomeSun = async () => {
+    hass.states['sensor.solar_power'].state = "5";
+    hass.states['sensor.battery_power'].state = "637";
+    hass.states['sensor.grid_power_consumption'].state = "0";
+    hass.states['sensor.grid_power_production'].state = "179";
+    card.setAttribute('hass', JSON.stringify(hass));
+    await elementUpdated(card);
+    await card.setConfig(config);
+  };
+
+  const setCardBatterySoC = async () => {
+    config.battery_soc_entity = "sensor.battery_soc";
+    hass.states['sensor.battery_soc'] = {
+      attributes: {
+        unit_of_measurement: "%",
+      },
+      entity_id: "sensor.battery_soc",
+      state: "89",
+    };
+    card.setAttribute('hass', JSON.stringify(hass));
+    await elementUpdated(card);
+    await card.setConfig(config);
+  };
+
+  it('has set card property values after setConfig', () => {
+    assert.isTrue(card.views.power.batteryCapable, 'Card property views should have value set for power view battery capability');
+  });
+
+  it('has ui elements', () => {
+    assert.equal(card.shadowRoot.querySelector('#icon-battery').getAttribute('icon'), 'mdi:car-battery', 'Battery icon should be default icon');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2battery').getAttribute('icon'), 'mdi:arrow-right', 'Solar2Battery icon should be normal icon');
+    assert.equal(card.shadowRoot.querySelector('#icon-battery2home').getAttribute('icon'), 'mdi:arrow-down', 'Battery2Home icon should be normal icon');
+    assert.equal(card.shadowRoot.querySelector('#cell-battery').getAttribute('title'), '', 'Battery title should be set');
+    assert.equal(card.shadowRoot.querySelector('#cell-solar2battery').getAttribute('title'), 'More info', 'Solar2Battery title should be set');
+    assert.equal(card.shadowRoot.querySelector('#cell-battery2home').getAttribute('title'), 'More info', 'Battery2Home title should be set');
+    assert.isTrue(card.shadowRoot.querySelector('#cell-grid2battery').classList.contains('hidden'), 'Grid2Battery arrow should be disabled');
+  });
+
+  it('displays values when consuming from solar, the grid and the battery', () => {
+    assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '500', 'Solar should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-1800', 'Grid should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-2600', 'Home should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-battery').innerText, '-300', 'Battery should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2battery').innerText, '', 'Solar2Battery arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid2battery').innerText, '', 'Grid2Battery arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-battery2home').innerText, '', 'Battery2Home arrow shouldn\'t have a value');
+  });
+
+  it('has ui elements when consuming from solar, the grid and the battery', () => {
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('producing'), 'Solar icon should be producing');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('consuming'), 'Grid icon should be consuming');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('consuming'), 'Home icon should be consuming');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-battery').classList.contains('consuming'), 'Battery icon should be consuming');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
+    assert.equal(card.shadowRoot.querySelector('#icon-grid2home').getAttribute('icon'), 'mdi:arrow-right', 'Grid2Home icon should be normal icon');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2battery').getAttribute('icon'), 'mdi:arrow-right', 'Solar2Battery icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#cell-grid2battery').classList.contains('hidden'), 'Grid2Battery cell should be hidden');
+    assert.equal(card.shadowRoot.querySelector('#icon-grid2battery').getAttribute('icon'), 'mdi:arrow-up', 'Grid2Battery icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid2battery').classList.contains('inactive'), 'Grid2Battery arrow icon should be inactive');
+    assert.equal(card.shadowRoot.querySelector('#icon-battery2home').getAttribute('icon'), 'mdi:arrow-down', 'Battery2Home icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('inactive'), 'Solar2Grid arrow icon should be inactive');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('active'), 'Solar2Home arrow icon should be active');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('active'), 'Grid2Home arrow icon should be active');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2battery').classList.contains('inactive'), 'Solar2Battery arrow icon should be inactive');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-battery2home').classList.contains('active'), 'Battery2Home arrow icon should be active');
+  });
+
+  it('displays values when producing to the grid while consuming from the battery', async () => {
+    await setCardProducingToGrid();
+
+    assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '500', 'Solar should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '50', 'Grid should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-350', 'Home should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-battery').innerText, '100', 'Battery should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2battery').innerText, '', 'Solar2Battery arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid2battery').innerText, '', 'Grid2Battery arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-battery2home').innerText, '', 'Battery2Home arrow shouldn\'t have a value');
+  });
+
+  it('has ui elements when producing to the grid while consuming from the battery', async () => {
+    await setCardProducingToGrid();
+
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('producing'), 'Solar icon should be producing');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('producing'), 'Grid icon should be producing');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('consuming'), 'Home icon should be consuming');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-battery').classList.contains('producing'), 'Battery icon should be producing');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
+    assert.equal(card.shadowRoot.querySelector('#icon-grid2home').getAttribute('icon'), 'mdi:arrow-right', 'Grid2Home icon should be normal icon');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2battery').getAttribute('icon'), 'mdi:arrow-right', 'Solar2Battery icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#cell-grid2battery').classList.contains('hidden'), 'Grid2Battery cell should be hidden');
+    assert.equal(card.shadowRoot.querySelector('#icon-grid2battery').getAttribute('icon'), 'mdi:arrow-up', 'Grid2Battery icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid2battery').classList.contains('inactive'), 'Grid2Battery arrow icon should be inactive');
+    assert.equal(card.shadowRoot.querySelector('#icon-battery2home').getAttribute('icon'), 'mdi:arrow-down', 'Battery2Home icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('active'), 'Solar2Grid arrow icon should be active');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('active'), 'Solar2Home arrow icon should be active');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('inactive'), 'Grid2Home arrow icon should be inactive');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2battery').classList.contains('active'), 'Solar2Battery arrow icon should be active');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-battery2home').classList.contains('inactive'), 'Battery2Home arrow icon should be inactive');
+  });
+
+  it('displays values when all sensor values are zero', async () => {
+    await setCardAllInactive(card, hass, config);
+
+    assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '0', 'Solar should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '0', 'Grid should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '0', 'Home should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-battery').innerText, '0', 'Battery should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2battery').innerText, '', 'Solar2Battery arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid2battery').innerText, '', 'Grid2Battery arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-battery2home').innerText, '', 'Battery2Home arrow shouldn\'t have a value');
+  });
+
+  it('has ui elements when all sensor values are zero', async () => {
+    await setCardAllInactive(card, hass, config);
+
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('inactive'), 'Solar icon should be inactive');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('inactive'), 'Grid icon should be inactive');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('inactive'), 'Home icon should be inactive');
+    assert.isTrue(card.shadowRoot.querySelector('#cell-battery').classList.contains('hidden'), 'Battery cell should be hidden');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-battery').classList.contains('inactive'), 'Battery icon should be inactive');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
+    assert.equal(card.shadowRoot.querySelector('#icon-grid2home').getAttribute('icon'), 'mdi:arrow-right', 'Grid2Home icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#cell-solar2battery').classList.contains('hidden'), 'Solar2Battery cell should be hidden');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2battery').getAttribute('icon'), 'mdi:arrow-right', 'Solar2Battery icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2battery').classList.contains('inactive'), 'Solar2Battery arrow icon should be inactive');
+    assert.isTrue(card.shadowRoot.querySelector('#cell-grid2battery').classList.contains('hidden'), 'Grid2Battery cell should be hidden');
+    assert.equal(card.shadowRoot.querySelector('#icon-grid2battery').getAttribute('icon'), 'mdi:arrow-up', 'Grid2Battery icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid2battery').classList.contains('inactive'), 'Grid2Battery arrow icon should be inactive');
+    assert.isTrue(card.shadowRoot.querySelector('#cell-battery2home').classList.contains('hidden'), 'Battery2Home cell should be hidden');
+    assert.equal(card.shadowRoot.querySelector('#icon-battery2home').getAttribute('icon'), 'mdi:arrow-down', 'Battery2Home icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-battery2home').classList.contains('inactive'), 'Battery2Home arrow icon should be inactive');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('inactive'), 'Solar2Grid arrow icon should be inactive');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('inactive'), 'Solar2Home arrow icon should be inactive');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('inactive'), 'Grid2Home arrow icon should be inactive');
+  });
+
+  it('displays values when charging the battery by the sun', async () => {
+    await setCardBatteryChargedBySolar();
+
+    assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '500', 'Solar should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '0', 'Grid should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-220', 'Home should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-battery').innerText, '280', 'Battery should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid2battery').innerText, '', 'Grid2Battery arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2battery').innerText, '', 'Solar2Battery arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-battery2home').innerText, '', 'Battery2Home arrow shouldn\'t have a value');
+  });
+
+  it('has ui elements when charging the battery by the sun', async () => {
+    await setCardBatteryChargedBySolar();
+
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('producing'), 'Solar icon should be producing');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('inactive'), 'Grid icon should be inactive');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('consuming'), 'Home icon should be consuming');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-battery').classList.contains('producing'), 'Battery icon should be producing');
+    assert.isTrue(card.shadowRoot.querySelector('#cell-grid2battery').classList.contains('hidden'), 'Grid2Battery cell should be hidden');
+    assert.equal(card.shadowRoot.querySelector('#icon-grid2battery').getAttribute('icon'), 'mdi:arrow-up', 'Grid2Battery icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid2battery').classList.contains('inactive'), 'Grid2Battery arrow icon should be inactive');
+    assert.equal(card.shadowRoot.querySelector('#icon-grid2home').getAttribute('icon'), 'mdi:arrow-right', 'Grid2Home icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('inactive'), 'Grid2Home arrow icon should be inactive');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('active'), 'Solar2Home arrow icon should be active');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2battery').getAttribute('icon'), 'mdi:arrow-right', 'Solar2Battery icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2battery').classList.contains('active'), 'Solar2Battery arrow icon should be active');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('inactive'), 'Solar2Grid arrow icon should be inactive');
+    assert.equal(card.shadowRoot.querySelector('#icon-battery2home').getAttribute('icon'), 'mdi:arrow-down', 'Battery2Home icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-battery2home').classList.contains('inactive'), 'Battery2Home arrow icon should be inactive');
+  });
+
+  it('displays values when charging the battery by the sun while producing to the grid', async () => {
+    await setCardBatteryChargedBySolarAndProducingToGrid();
+
+    assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '500', 'Solar should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '100', 'Grid should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-120', 'Home should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-battery').innerText, '280', 'Battery should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2battery').innerText, '', 'Solar2Battery arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid2battery').innerText, '', 'Grid2Battery arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-battery2home').innerText, '', 'Battery2Home arrow shouldn\'t have a value');
+  });
+
+  it('has ui elements when charging the battery by the sun while producing to the grid', async () => {
+    await setCardBatteryChargedBySolarAndProducingToGrid();
+
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('producing'), 'Solar icon should be producing');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('producing'), 'Grid icon should be producing');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('consuming'), 'Home icon should be consuming');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-battery').classList.contains('producing'), 'Battery icon should be producing');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
+    assert.equal(card.shadowRoot.querySelector('#icon-grid2home').getAttribute('icon'), 'mdi:arrow-right', 'Grid2Home icon should be normal icon');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2battery').getAttribute('icon'), 'mdi:arrow-right', 'Solar2Battery icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#cell-grid2battery').classList.contains('hidden'), 'Grid2Battery cell should be hidden');
+    assert.equal(card.shadowRoot.querySelector('#icon-grid2battery').getAttribute('icon'), 'mdi:arrow-up', 'Grid2Battery icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid2battery').classList.contains('inactive'), 'Grid2Battery arrow icon should be inactive');
+    assert.equal(card.shadowRoot.querySelector('#icon-battery2home').getAttribute('icon'), 'mdi:arrow-down', 'Battery2Home icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('active'), 'Solar2Grid arrow icon should be active');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('active'), 'Solar2Home arrow icon should be active');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('inactive'), 'Grid2Home arrow icon should be inactive');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2battery').classList.contains('active'), 'Solar2Battery arrow icon should be active');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-battery2home').classList.contains('inactive'), 'Battery2Home arrow icon should be inactive');
+  });
+
+  it('displays values when charging the battery by the grid', async () => {
+    await setCardBatteryChargedByGrid();
+
+    assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '0', 'Solar should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '-1800', 'Grid should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-battery').innerText, '280', 'Battery should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-1520', 'Home should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2battery').innerText, '', 'Solar2Battery arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid2battery').innerText, '', 'Grid2Battery arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-battery2home').innerText, '', 'Battery2Home arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
+  });
+
+  it('has ui elements when charging the battery by the grid', async () => {
+    await setCardBatteryChargedByGrid();
+
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('inactive'), 'Solar icon should be inactive');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('consuming'), 'Grid icon should be consuming');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('consuming'), 'Home icon should be consuming');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-battery').classList.contains('producing'), 'Battery icon should be producing');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
+    assert.equal(card.shadowRoot.querySelector('#icon-grid2home').getAttribute('icon'), 'mdi:arrow-right', 'Grid2Home icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#cell-solar2battery').classList.contains('hidden'), 'Solar2Battery cell should be hidden');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2battery').getAttribute('icon'), 'mdi:arrow-right', 'Solar2Battery icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2battery').classList.contains('inactive'), 'Solar2Battery arrow icon should be inactive');
+    assert.equal(card.shadowRoot.querySelector('#icon-grid2battery').getAttribute('icon'), 'mdi:arrow-up', 'Grid2Battery icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#cell-battery2home').classList.contains('hidden'), 'Battery2Home cell should be hidden');
+    assert.equal(card.shadowRoot.querySelector('#icon-battery2home').getAttribute('icon'), 'mdi:arrow-down', 'Battery2Home icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-battery2home').classList.contains('inactive'), 'Battery2Home arrow icon should be inactive');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('inactive'), 'Solar2Grid arrow icon should be inactive');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('inactive'), 'Solar2Home arrow icon should be inactive');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('active'), 'Grid2Home arrow icon should be active');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid2battery').classList.contains('active'), 'Grid2Battery arrow icon should be active');
+  });
+
+  it('displays values when discharging the battery while producing to the grid', async () => {
+    await setCardBatteryDischargedWhenProducingToGrid();
+
+    assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '0', 'Solar should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-battery').innerText, '-1228', 'Battery should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-battery2home').innerText, '', 'Battery2Home arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2battery').innerText, '', 'Solar2Battery arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid2battery').innerText, '', 'Grid2Battery arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '171', 'Grid should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-1057', 'Home should have correct value');
+  });
+
+  it('has ui elements when discharging the battery while producing to the grid', async () => {
+    await setCardBatteryDischargedWhenProducingToGrid();
+
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('inactive'), 'Solar icon should be inactive');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('inactive'), 'Solar2Grid arrow icon should be inactive');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-battery').classList.contains('consuming'), 'Battery icon should be consuming');
+    assert.equal(card.shadowRoot.querySelector('#icon-battery2home').getAttribute('icon'), 'mdi:arrow-down', 'Battery2Home icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-battery2home').classList.contains('active'), 'Battery2Home arrow icon should be active');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2battery').getAttribute('icon'), 'mdi:arrow-right', 'Solar2Battery icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2battery').classList.contains('inactive'), 'Solar2Battery arrow icon should be inactive');
+    assert.equal(card.shadowRoot.querySelector('#icon-grid2battery').getAttribute('icon'), 'mdi:arrow-down', 'Grid2Battery icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid2battery').classList.contains('active'), 'Grid2Battery arrow icon should be active');
+    assert.equal(card.shadowRoot.querySelector('#icon-grid2home').getAttribute('icon'), 'mdi:arrow-right', 'Grid2Home icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('inactive'), 'Grid2Home arrow icon should be inactive');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('producing'), 'Grid icon should be producing');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('inactive'), 'Solar2Home arrow icon should be inactive');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('consuming'), 'Home icon should be consuming');
+  });
+
+  it('displays values when discharging the battery while producing to the grid and some sun', async () => {
+    await setCardBatteryDischargedWhenProducingToGridAndSomeSun();
+
+    assert.equal(card.shadowRoot.querySelector('#value-solar').innerText, '5', 'Solar should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid').innerText, '179', 'Grid should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-home').innerText, '-463', 'Home should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-battery').innerText, '-637', 'Battery should have correct value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2grid').innerText, '', 'Solar2Grid arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-battery2home').innerText, '458', 'Battery2Home arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2battery').innerText, '', 'Solar2Battery arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid2battery').innerText, '', 'Grid2Battery arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-grid2home').innerText, '', 'Grid2Home arrow shouldn\'t have a value');
+    assert.equal(card.shadowRoot.querySelector('#value-solar2home').innerText, '', 'Solar2Home arrow shouldn\'t have a value');
+  });
+
+  it('has ui elements when discharging the battery while producing to the grid and some sun', async () => {
+    await setCardBatteryDischargedWhenProducingToGridAndSomeSun();
+
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar').classList.contains('producing'), 'Solar icon should be producing');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid').classList.contains('producing'), 'Grid icon should be producing');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-home').classList.contains('consuming'), 'Home icon should be consuming');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-battery').classList.contains('consuming'), 'Battery icon should be consuming');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2grid').getAttribute('icon'), 'mdi:arrow-bottom-left', 'Solar2Grid icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2grid').classList.contains('inactive'), 'Solar2Grid arrow icon should be inactive');
+    assert.equal(card.shadowRoot.querySelector('#icon-battery2home').getAttribute('icon'), 'mdi:arrow-down', 'Battery2Home icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-battery2home').classList.contains('active'), 'Battery2Home arrow icon should be active');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2battery').getAttribute('icon'), 'mdi:arrow-right', 'Solar2Battery icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2battery').classList.contains('inactive'), 'Solar2Battery arrow icon should be inactive');
+    assert.equal(card.shadowRoot.querySelector('#icon-grid2battery').getAttribute('icon'), 'mdi:arrow-down', 'Grid2Battery icon should be reversed icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid2battery').classList.contains('active'), 'Grid2Battery arrow icon should be active');
+    assert.equal(card.shadowRoot.querySelector('#icon-grid2home').getAttribute('icon'), 'mdi:arrow-right', 'Grid2Home icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-grid2home').classList.contains('inactive'), 'Grid2Home arrow icon should be inactive');
+    assert.equal(card.shadowRoot.querySelector('#icon-solar2home').getAttribute('icon'), 'mdi:arrow-bottom-right', 'Solar2Home icon should be normal icon');
+    assert.isTrue(card.shadowRoot.querySelector('#icon-solar2home').classList.contains('active'), 'Solar2Home arrow icon should be active');
+  });
+
+  it('displays values for battery state of charge', async () => {
+    await setCardBatterySoC();
+
+    assert.equal(card.shadowRoot.querySelector('#cell-battery').getAttribute('title'), 'More info', 'Battery title should be set');
+    assert.equal(card.shadowRoot.querySelector('#value-battery').innerText, '-300 (89%)', 'Battery should have correct value');
+  });
+
+});

--- a/test/energy_capable.test.js
+++ b/test/energy_capable.test.js
@@ -13,6 +13,7 @@ describe('<power-wheel-card> with energy view capable config', () => {
   beforeEach(async () => {
     config = {
       type: "custom:power-wheel-card",
+      title: "Power wheel",
       solar_power_entity: "sensor.solar_power",
       grid_power_consumption_entity: "sensor.grid_power_consumption",
       grid_power_production_entity: "sensor.grid_power_production",

--- a/test/energy_one_grid_sensor.test.js
+++ b/test/energy_one_grid_sensor.test.js
@@ -14,6 +14,7 @@ describe('<power-wheel-card> with energy view capable config for one grid sensor
   beforeEach(async () => {
     config = {
       type: "custom:power-wheel-card",
+      title: "Power wheel",
       solar_power_entity: "sensor.solar_power",
       grid_power_consumption_entity: "sensor.grid_power_consumption",
       grid_power_production_entity: "sensor.grid_power_production",

--- a/test/energy_one_grid_sensor_switched_polarity.test.js
+++ b/test/energy_one_grid_sensor_switched_polarity.test.js
@@ -14,6 +14,7 @@ describe('<power-wheel-card> with energy view capable config for one grid sensor
   beforeEach(async () => {
     config = {
       type: "custom:power-wheel-card",
+      title: "Power wheel",
       solar_power_entity: "sensor.solar_power",
       grid_power_consumption_entity: "sensor.grid_power_consumption",
       grid_power_production_entity: "sensor.grid_power_production",

--- a/test/money_capable.test.js
+++ b/test/money_capable.test.js
@@ -13,6 +13,7 @@ describe('<power-wheel-card> with money view capable config', () => {
   beforeEach(async () => {
     config = {
       type: "custom:power-wheel-card",
+      title: "Power wheel",
       solar_power_entity: "sensor.solar_power",
       grid_power_consumption_entity: "sensor.grid_power_consumption",
       grid_power_production_entity: "sensor.grid_power_production",

--- a/test/money_energy_production_rate.test.js
+++ b/test/money_energy_production_rate.test.js
@@ -12,6 +12,7 @@ describe('<power-wheel-card> with split energy rates', () => {
   beforeEach(async () => {
     config = {
       type: "custom:power-wheel-card",
+      title: "Power wheel",
       solar_power_entity: "sensor.solar_power",
       grid_power_consumption_entity: "sensor.grid_power_consumption",
       grid_power_production_entity: "sensor.grid_power_production",


### PR DESCRIPTION
## 0.1.2
### New features
* Allowing to hide the title. Default value for `title` is empty now. If you want the previous behavior you could add `title: 'Power wheel'` to your config. Issue #51.
* ** BETA.** You can switch the polarity of `battery_power_entity` with the new card parameter `charging_is_positive`. No need to make an extra template sensor for this anymore. Issue #46.
### Improvements
* Removed deprecated input parameter `energy_price`. This parameter was deprecated since version 0.1.0.
### Fixes 
* After a startup of HA sensor validation errors stayed visible since the new startup order of HA 0.111.0. Sensor validation is disabled temporarily. 
